### PR TITLE
Various fixes

### DIFF
--- a/src/epub/text/book-1.xhtml
+++ b/src/epub/text/book-1.xhtml
@@ -967,7 +967,7 @@
 					<br/>
 					<span>Him followed Rimmon, whose delightful seat</span>
 					<br/>
-					<span>Was fair Damscus, on the fertile banks</span>
+					<span>Was fair Damascus, on the fertile banks</span>
 					<br/>
 					<span>Of Abbana and Pharphar, lucid streams.</span>
 					<br/>

--- a/src/epub/text/book-1.xhtml
+++ b/src/epub/text/book-1.xhtml
@@ -1549,7 +1549,7 @@
 					<br/>
 					<span>A solemn council forthwith to be held</span>
 					<br/>
-					<span>At Pandaemonium, the high capital</span>
+					<span>At Pandemonium, the high capital</span>
 					<br/>
 					<span>Of Satan and his peers. Their summons called</span>
 					<br/>

--- a/src/epub/text/book-11.xhtml
+++ b/src/epub/text/book-11.xhtml
@@ -348,7 +348,7 @@
 					<span>Man is to live, and all things live for Man.”</span>
 				</p>
 				<p>
-					<span>To whom thus Eve with sad demeanour meek;</span>
+					<span>To whom thus Eve with sad demeanour meek:</span>
 					<br/>
 					<span>“Ill-worthy I such title should belong</span>
 					<br/>

--- a/src/epub/text/book-6.xhtml
+++ b/src/epub/text/book-6.xhtml
@@ -368,7 +368,7 @@
 				<p>
 					<span>“To whom, in brief, thus Abdiel stern replied:</span>
 					<br/>
-					<span>Apostate! still thou err’st, nor end wilt find</span>
+					<span>‘Apostate! still thou err’st, nor end wilt find</span>
 					<br/>
 					<span>Of erring, from the path of truth remote.</span>
 					<br/>


### PR DESCRIPTION
The first two commits propose to change the spelling of some names so they match the source scans. The reasoning for these changes and links to the relevant pages are included in the extended commit messages.

The third commit fixes obvious typos.