### PR TITLE
Modernize spellings

### DIFF
--- a/src/epub/text/book-1.xhtml
+++ b/src/epub/text/book-1.xhtml
@@ -518,7 +518,7 @@
 					<br/>
 					<span>For that celestial light? Be it so, since he</span>
 					<br/>
-					<span>Who now is sovran can dispose and bid</span>
+					<span>Who now is sovereign can dispose and bid</span>
 					<br/>
 					<span>What shall be right: farthest from him is best,</span>
 					<br/>
@@ -1543,7 +1543,7 @@
 				<p>
 					<span>Meanwhile the winged haralds, by command</span>
 					<br/>
-					<span>Of sovran power, with awful ceremony</span>
+					<span>Of sovereign power, with awful ceremony</span>
 					<br/>
 					<span>And trumpet’s sound, throughout the host proclaim</span>
 					<br/>

--- a/src/epub/text/book-10.xhtml
+++ b/src/epub/text/book-10.xhtml
@@ -1336,7 +1336,7 @@
 				<p>
 					<span>He ended, and the Heavenly audience loud</span>
 					<br/>
-					<span>Sung Halleluiah, as the sound of seas,</span>
+					<span>Sung Hallelujah, as the sound of seas,</span>
 					<br/>
 					<span>Through multitude that sung: “Just are thy ways,</span>
 					<br/>

--- a/src/epub/text/book-10.xhtml
+++ b/src/epub/text/book-10.xhtml
@@ -317,7 +317,7 @@
 					<span>She gave me of the tree, and I did eat.”</span>
 				</p>
 				<p>
-					<span>To whom the Sovran Presence thus replied:</span>
+					<span>To whom the Sovereign Presence thus replied:</span>
 					<br/>
 					<span>“Was she thy God, that her thou didst obey</span>
 					<br/>

--- a/src/epub/text/book-11.xhtml
+++ b/src/epub/text/book-11.xhtml
@@ -186,7 +186,7 @@
 					<br/>
 					<span>And took their seats, till from his throne supreme</span>
 					<br/>
-					<span>The Almighty thus pronounced his sovran will:</span>
+					<span>The Almighty thus pronounced his sovereign will:</span>
 				</p>
 				<p>
 					<span>“O Sons, like one of us Man is become</span>

--- a/src/epub/text/book-12.xhtml
+++ b/src/epub/text/book-12.xhtml
@@ -89,7 +89,7 @@
 					<br/>
 					<span>Before the Lord, as in despite of Heaven,</span>
 					<br/>
-					<span>Or from Heaven claiming second sovranty;</span>
+					<span>Or from Heaven claiming second sovereignty;</span>
 					<br/>
 					<span>And from rebellion shall derive his name,</span>
 					<br/>

--- a/src/epub/text/book-2.xhtml
+++ b/src/epub/text/book-2.xhtml
@@ -512,7 +512,7 @@
 					<br/>
 					<span>Forced Halleluiahs; while he lordly sits</span>
 					<br/>
-					<span>Our envied sovran, and his altar breathes</span>
+					<span>Our envied sovereign, and his altar breathes</span>
 					<br/>
 					<span>Ambrosial odours and ambrosial flowers,</span>
 					<br/>
@@ -921,7 +921,7 @@
 					<br/>
 					<span>But I should ill become this Throne, O Peers,</span>
 					<br/>
-					<span>And this imperial sovranty, adorned</span>
+					<span>And this imperial sovereignty, adorned</span>
 					<br/>
 					<span>With splendour, armed with power, if aught proposed</span>
 					<br/>

--- a/src/epub/text/book-2.xhtml
+++ b/src/epub/text/book-2.xhtml
@@ -510,7 +510,7 @@
 					<br/>
 					<span>With warbled hymns, and to his Godhead sing</span>
 					<br/>
-					<span>Forced Halleluiahs; while he lordly sits</span>
+					<span>Forced Hallelujahs; while he lordly sits</span>
 					<br/>
 					<span>Our envied sovereign, and his altar breathes</span>
 					<br/>

--- a/src/epub/text/book-3.xhtml
+++ b/src/epub/text/book-3.xhtml
@@ -61,7 +61,7 @@
 					<br/>
 					<span>Though hard and rare: thee I revisit safe,</span>
 					<br/>
-					<span>And feel thy sovran vital lamp; but thou</span>
+					<span>And feel thy sovereign vital lamp; but thou</span>
 					<br/>
 					<span>Revisit’st not these eyes, that roll in vain</span>
 					<br/>
@@ -311,7 +311,7 @@
 				<p>
 					<span>“O Father, gracious was that word which closed</span>
 					<br/>
-					<span>Thy sovran sentence, that Man should find grace;</span>
+					<span>Thy sovereign sentence, that Man should find grace;</span>
 					<br/>
 					<span>For which both Heaven and Earth shall high extol</span>
 					<br/>

--- a/src/epub/text/book-4.xhtml
+++ b/src/epub/text/book-4.xhtml
@@ -1419,7 +1419,7 @@
 					<br/>
 					<span>On to their blissful bower. It was a place</span>
 					<br/>
-					<span>Chosen by the sovran Planter, when he framed</span>
+					<span>Chosen by the sovereign Planter, when he framed</span>
 					<br/>
 					<span>All things to Man’s delightful use. The roof</span>
 					<br/>

--- a/src/epub/text/book-5.xhtml
+++ b/src/epub/text/book-5.xhtml
@@ -538,7 +538,7 @@
 					<br/>
 					<span>On golden hinges turning, as by work</span>
 					<br/>
-					<span>Divine the sovran Architect had framed.</span>
+					<span>Divine the sovereign Architect had framed.</span>
 					<br/>
 					<span>From hence⁠—no cloud or, to obstruct his sight,</span>
 					<br/>
@@ -762,7 +762,7 @@
 					<br/>
 					<span>To want, and honour these, vouchsafe with us,</span>
 					<br/>
-					<span>Two only, who yet by sovran gift possess</span>
+					<span>Two only, who yet by sovereign gift possess</span>
 					<br/>
 					<span>This spacious ground, in yonder shady bower</span>
 					<br/>
@@ -1356,7 +1356,7 @@
 					<br/>
 					<span>Fanned with cool winds; save those who, in their course,</span>
 					<br/>
-					<span>Melodious hymns about the sovran throne</span>
+					<span>Melodious hymns about the sovereign throne</span>
 					<br/>
 					<span>Alternate all night long. But not so waked</span>
 					<br/>

--- a/src/epub/text/book-6.xhtml
+++ b/src/epub/text/book-6.xhtml
@@ -1535,7 +1535,7 @@
 					<br/>
 					<span>Far separate, circling thy holy mount,</span>
 					<br/>
-					<span>Unfeigned halleluiahs to thee sing,</span>
+					<span>Unfeigned hallelujahs to thee sing,</span>
 					<br/>
 					<span>Hymns of high praise, and I among them chief.’</span>
 				</p>

--- a/src/epub/text/book-6.xhtml
+++ b/src/epub/text/book-6.xhtml
@@ -131,7 +131,7 @@
 					<span>His fiery chaos to receive their fall.’</span>
 				</p>
 				<p>
-					<span>“So spake the Sovran Voice, and clouds began</span>
+					<span>“So spake the Sovereign Voice, and clouds began</span>
 					<br/>
 					<span>To darken all the hill, and smoke to roll</span>
 					<br/>

--- a/src/epub/text/book-7.xhtml
+++ b/src/epub/text/book-7.xhtml
@@ -177,7 +177,7 @@
 					<br/>
 					<span>Receive with solemn purpose to observe</span>
 					<br/>
-					<span>Immutably his sovran will, the end</span>
+					<span>Immutably his sovereign will, the end</span>
 					<br/>
 					<span>Of what we are. But, since thou hast vouchsafed</span>
 					<br/>

--- a/src/epub/text/book-7.xhtml
+++ b/src/epub/text/book-7.xhtml
@@ -1304,7 +1304,7 @@
 				<p>
 					<span>“So sung they, and the Empyrean rung</span>
 					<br/>
-					<span>With halleluiahs. Thus was Sabbath kept.</span>
+					<span>With hallelujahs. Thus was Sabbath kept.</span>
 					<br/>
 					<span>And thy request think now fulfilled, that asked</span>
 					<br/>

--- a/src/epub/text/book-8.xhtml
+++ b/src/epub/text/book-8.xhtml
@@ -500,7 +500,7 @@
 					<br/>
 					<span>But us he sends upon his high behests</span>
 					<br/>
-					<span>For state, as sovran King, and to inure</span>
+					<span>For state, as sovereign King, and to inure</span>
 					<br/>
 					<span>Our prompt obedience. Fast we found, fast shut,</span>
 					<br/>
@@ -1330,7 +1330,7 @@
 					<br/>
 					<span>Go, Heavenly guest, Ethereal messenger,</span>
 					<br/>
-					<span>Sent from whose sovran goodness I adore!</span>
+					<span>Sent from whose sovereign goodness I adore!</span>
 					<br/>
 					<span>Gentle to me and affable hath been</span>
 					<br/>

--- a/src/epub/text/book-9.xhtml
+++ b/src/epub/text/book-9.xhtml
@@ -1100,7 +1100,7 @@
 					<span>His fraudulent temptation thus began:</span>
 				</p>
 				<p>
-					<span>“Wonder not, sovran mistress, if perhaps</span>
+					<span>“Wonder not, sovereign mistress, if perhaps</span>
 					<br/>
 					<span>Thou canst who art sole wonder; much less arm</span>
 					<br/>
@@ -1263,7 +1263,7 @@
 					<br/>
 					<span>And gaze, and worship thee of right declared</span>
 					<br/>
-					<span>Sovran of creatures, universal Dame!”</span>
+					<span>Sovereign of creatures, universal Dame!”</span>
 				</p>
 				<p>
 					<span>So talked the spirited sly Snake; and Eve,</span>
@@ -1642,7 +1642,7 @@
 					<span>Thus to herself she pleasingly began:</span>
 				</p>
 				<p>
-					<span>“O sovran, virtuous, precious of all trees</span>
+					<span>“O sovereign, virtuous, precious of all trees</span>
 					<br/>
 					<span>In Paradise! of operation blest</span>
 					<br/>
@@ -2325,7 +2325,7 @@
 					<br/>
 					<span>To sensual Appetite, who, from beneath</span>
 					<br/>
-					<span>Usurping over sovran Reason, claimed</span>
+					<span>Usurping over sovereign Reason, claimed</span>
 					<br/>
 					<span>Superior sway. From thus distempered breast</span>
 					<br/>


### PR DESCRIPTION
I noticed that many editions on Google Books, maybe even the majority, modernize “sovran” to “sovereign” or “sov’reign.” This was gratifying, as I found the “sovran” spelling incredibly distracting the whole time I read the book.

“Sov’reign” is a better choice than “sovereign” as it preserves the meter.